### PR TITLE
fix: compact leaderboard & login buttons to prevent layout overflow

### DIFF
--- a/src/components/LoginButtons.tsx
+++ b/src/components/LoginButtons.tsx
@@ -3,13 +3,13 @@ import { labels } from '../utils/labels'
 import { getLoginUrl } from '../utils/auth'
 
 const GitHubIcon = () => (
-  <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" className="shrink-0">
+  <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" className="shrink-0">
     <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
   </svg>
 )
 
 const GoogleIcon = () => (
-  <svg viewBox="0 0 24 24" width="18" height="18" className="shrink-0">
+  <svg viewBox="0 0 24 24" width="14" height="14" className="shrink-0">
     <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
     <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
     <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
@@ -40,20 +40,20 @@ export function LoginButtons({ returnTo, variant = 'signIn', className = '' }: L
   const googleLabel = variant === 'submit' ? t(labels.signInWithGoogle) : t(labels.signInGoogle)
 
   return (
-    <div className={`flex flex-col sm:flex-row items-stretch justify-center gap-3 w-full ${className}`}>
+    <div className={`flex flex-col sm:flex-row items-stretch justify-center gap-2 w-full min-w-0 ${className}`}>
       <a
         href={getLoginUrl('github', returnTo)}
-        className="flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl bg-gray-900/10 dark:bg-white/10 border-2 border-gray-900/20 dark:border-white/20 hover:bg-gray-900/20 dark:hover:bg-white/20 transition-all duration-200 text-sm font-medium whitespace-nowrap sm:flex-1"
+        className="flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl bg-gray-900/10 dark:bg-white/10 border-2 border-gray-900/20 dark:border-white/20 hover:bg-gray-900/20 dark:hover:bg-white/20 transition-all duration-200 text-xs font-medium whitespace-nowrap sm:flex-1"
       >
         <GitHubIcon />
-        <span>{githubLabel}</span>
+        {githubLabel}
       </a>
       <a
         href={getLoginUrl('google', returnTo)}
-        className="flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl bg-blue-500/10 border-2 border-blue-500/20 hover:bg-blue-500/20 transition-all duration-200 text-sm font-medium text-blue-700 dark:text-blue-400 whitespace-nowrap sm:flex-1"
+        className="flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl bg-blue-500/10 border-2 border-blue-500/20 hover:bg-blue-500/20 transition-all duration-200 text-xs font-medium text-blue-700 dark:text-blue-400 whitespace-nowrap sm:flex-1"
       >
         <GoogleIcon />
-        <span>{googleLabel}</span>
+        {googleLabel}
       </a>
     </div>
   )

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -364,7 +364,7 @@ export function ResultsPage() {
                 </button>
               </div>
             ) : questionsCommitSha ? (
-              <div className="flex flex-col gap-2 sm:flex-row sm:gap-3">
+              <div className="flex flex-col gap-2 sm:flex-row sm:gap-2">
                 {authStatus.authenticated ? (
                   <button
                     onClick={async () => {
@@ -389,23 +389,21 @@ export function ResultsPage() {
                       }
                     }}
                     disabled={submitting}
-                    className="flex items-center justify-center gap-2 px-4 py-2.5 sm:py-3 rounded-xl bg-amber-500/10 border-2 border-amber-500/30 hover:bg-amber-500/20 transition-all duration-200 text-sm sm:text-base font-medium text-amber-700 dark:text-amber-400 cursor-pointer disabled:opacity-50 sm:flex-1 sm:min-w-0"
+                    className="flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl bg-amber-500/10 border-2 border-amber-500/30 hover:bg-amber-500/20 transition-all duration-200 text-xs font-medium text-amber-700 dark:text-amber-400 cursor-pointer disabled:opacity-50 sm:flex-1 whitespace-nowrap"
                   >
-                    <Trophy size={16} className="shrink-0" />
-                    <span className="truncate">
-                      {submitting
-                        ? t(labels.leaderboardSubmitting)
-                        : t(labels.submitToLeaderboard)}
-                    </span>
+                    <Trophy size={14} className="shrink-0" />
+                    {submitting
+                      ? t(labels.leaderboardSubmitting)
+                      : t(labels.submitToLeaderboard)}
                   </button>
                 ) : (
                   <LoginButtons variant="submit" />
                 )}
                 <button
                   onClick={() => navigate("/leaderboard")}
-                  className="flex items-center justify-center gap-2 px-4 py-2.5 sm:py-3 rounded-xl border-2 border-border bg-surface hover:bg-surface-hover transition-all duration-200 text-sm sm:text-base font-medium cursor-pointer sm:shrink-0 sm:whitespace-nowrap"
+                  className="flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl border-2 border-border bg-surface hover:bg-surface-hover transition-all duration-200 text-xs font-medium cursor-pointer whitespace-nowrap"
                 >
-                  <Trophy size={16} className="text-amber-500" />
+                  <Trophy size={14} className="text-amber-500" />
                   {t(labels.viewLeaderboard)}
                 </button>
               </div>


### PR DESCRIPTION
## Problem

On the results page, when a user is **not logged in**, the login buttons (GitHub + Google) and the "View Leaderboard" button overflowed the container because all three tried to fit in a single row with large padding and text.

## Changes

### `LoginButtons.tsx`
- Reduced icon sizes from 18×18 → 14×14
- Reduced padding from `px-5 py-2.5` → `px-3 py-2`
- Reduced text from `text-sm` → `text-xs`
- Tightened gap spacing

### `ResultsPage.tsx`
- Applied matching compact sizing to the "Submit Result" and "View Leaderboard" buttons in the leaderboard row
- Icon sizes from 16 → 14, consistent `text-xs` and smaller padding

All three buttons now comfortably fit in a single row, even with longer German translations.