### PR TITLE
fix: round scoring to avoid FP precision misclassifying full-credit answers

### DIFF
--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -2,6 +2,10 @@ import type { PickQuestion, CategoryQuestion, Question } from '../data/schema'
 
 export const PASS_THRESHOLD = 0.6
 
+// Round to 10 decimals to strip IEEE-754 accumulation noise
+// (e.g. 6 × (2/6) summing to 1.9999999999999998 instead of 2).
+const roundScore = (n: number) => Math.round(n * 1e10) / 1e10
+
 export interface OptionResult {
   id: string
   isSelected: boolean
@@ -70,7 +74,7 @@ export function scorePickQuestion(question: PickQuestion, selectedIds: string[])
   })
 
   // Selecting more options than correct answers always results in 0 points
-  const finalScore = tooManySelected ? 0 : Math.max(0, rawScore)
+  const finalScore = tooManySelected ? 0 : Math.max(0, roundScore(rawScore))
 
   return {
     questionId: question.id,
@@ -114,7 +118,7 @@ export function scoreCategoryQuestion(
   return {
     questionId: question.id,
     type: 'category',
-    score: Math.max(0, rawScore),
+    score: Math.max(0, roundScore(rawScore)),
     maxPoints: question.points,
     rawScore,
     statementResults,


### PR DESCRIPTION
## Summary
- Fixes #33 — fully-correct answers on category questions like Q-20-04-31 ("reasons for architecture documentation") were rendered as "partly correct" in the results view.
- Root cause: `pointsPerStatement = points / statementsCount` is non-terminating for ratios like `2/6`, so accumulating 6 of those yields `1.9999999999999998` instead of `2`. The check `qr.score >= qr.maxPoints` in `ResultsPage.tsx` then fails and the question is labeled partial.
- Fix rounds the final score in both `scorePickQuestion` and `scoreCategoryQuestion` to strip IEEE-754 noise. Applying it at the source also keeps `totalScore` and `percentage` clean (an epsilon compare in the UI would not).

Other questions with the same shape (1/3, 2/6) — Q-17-13-02 and Q-20-04-12 — are fixed by the same change. Pick questions with non-terminating `points / correctCount` ratios are protected too.

## Test plan
- [x] `bun test tests/scoring.test.ts` — 19/19 pass
- [x] Manually run the Mock Exam, answer Q-20-04-31 fully correctly, confirm results page shows "Correct" with the green check

<img width="759" height="652" alt="image" src="https://github.com/user-attachments/assets/cc9824f2-547e-4de8-b383-497297f50c31" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)