### PR TITLE
fix: correctly handle umlauts in guest nicknames (#35) + related hardening

### DIFF
--- a/scripts/generateFallback.ts
+++ b/scripts/generateFallback.ts
@@ -22,9 +22,9 @@ async function main() {
 
   console.log(`Found ${filenames.length} question files\n`)
 
-  // linkedom DOMParser for server-side XML parsing
+  // linkedom DOMParser for server-side XML parsing — structurally satisfies XmlDomParser
   const { DOMParser } = await import('linkedom')
-  const domParser = new DOMParser() as unknown as globalThis.DOMParser
+  const domParser = new DOMParser()
 
   const questions = []
 

--- a/src/data/xmlParser.ts
+++ b/src/data/xmlParser.ts
@@ -10,6 +10,36 @@
  */
 import type { Question } from './schema'
 
+/**
+ * Minimal structural shape of the DOM subset this parser touches. Declared locally
+ * so the module is self-contained and typechecks identically everywhere it runs —
+ * the browser, the Worker (@xmldom/xmldom) and Node (linkedom) each ship a different
+ * ambient `Element`/`DOMParser`, and the Worker's tsconfig has no DOM lib at all.
+ * `children`/`childNodes` are typed as `ArrayLike<unknown>` because each node is
+ * narrowed by tag name before use; entries are cast to `XmlElement` at the call site.
+ */
+interface XmlElement {
+  readonly tagName: string
+  readonly localName: string | null
+  readonly textContent: string | null
+  readonly children?: ArrayLike<unknown>
+  readonly childNodes: ArrayLike<unknown>
+  getAttribute(qualifiedName: string): string | null
+  getAttributeNS?(namespace: string, localName: string): string | null
+  hasAttribute(qualifiedName: string): boolean
+  getElementsByTagName(qualifiedName: string): ArrayLike<XmlElement>
+}
+
+interface XmlDocument {
+  readonly documentElement: XmlElement | null
+  getElementsByTagName(qualifiedName: string): ArrayLike<XmlElement>
+}
+
+/** Spec-compatible DOMParser subset — browser-native, @xmldom/xmldom or linkedom. */
+export interface XmlDomParser {
+  parseFromString(source: string, type: string): XmlDocument
+}
+
 interface BilingualTexts {
   de: string
   en: string
@@ -19,12 +49,12 @@ interface BilingualTexts {
  * Extract bilingual {de, en} text from a parent element
  * that contains `<text xml:lang="de">...</text>` children.
  */
-export function getTexts(element: Element | null): BilingualTexts {
+export function getTexts(element: XmlElement | null): BilingualTexts {
   if (!element) return { de: '', en: '' }
   const result: BilingualTexts = { de: '', en: '' }
 
   for (const child of Array.from(element.children ?? element.childNodes)) {
-    const el = child as Element
+    const el = child as XmlElement
     if (el.localName === 'text' || el.tagName === 'text') {
       const lang =
         el.getAttribute('xml:lang') ??
@@ -39,15 +69,15 @@ export function getTexts(element: Element | null): BilingualTexts {
 }
 
 /** Get the first element matching a tag name (recursive, like querySelector) */
-function getFirstByTag(parent: Element, tagName: string): Element | null {
+function getFirstByTag(parent: XmlElement, tagName: string): XmlElement | null {
   const results = parent.getElementsByTagName(tagName)
   return results.length > 0 ? results[0] : null
 }
 
 /** Get all elements matching a tag name (recursive, like querySelectorAll) */
-function getAllByTag(parent: Element, tagName: string): Element[] {
+function getAllByTag(parent: XmlElement, tagName: string): XmlElement[] {
   const results = parent.getElementsByTagName(tagName)
-  const out: Element[] = []
+  const out: XmlElement[] = []
   for (let i = 0; i < results.length; i++) {
     out.push(results[i])
   }
@@ -59,7 +89,7 @@ function getAllByTag(parent: Element, tagName: string): Element[] {
  * Accepts a DOMParser instance so the caller can provide either
  * the browser-native DOMParser or @xmldom/xmldom's equivalent.
  */
-export function parseQuestionXml(xmlText: string, domParser: DOMParser): Question {
+export function parseQuestionXml(xmlText: string, domParser: XmlDomParser): Question {
   const doc = domParser.parseFromString(xmlText, 'text/xml')
 
   // Check for parse errors — browser uses <parsererror>, xmldom may throw
@@ -67,6 +97,7 @@ export function parseQuestionXml(xmlText: string, domParser: DOMParser): Questio
   if (parseErrors.length > 0) throw new Error(`XML parse error: ${parseErrors[0].textContent}`)
 
   const root = doc.documentElement
+  if (!root) throw new Error('XML document has no root element')
   const tagName = root.localName
   const id = root.getAttribute('id') ?? ''
   const points = parseInt(root.getAttribute('points') ?? '1', 10)

--- a/src/pages/SessionDetailPage.tsx
+++ b/src/pages/SessionDetailPage.tsx
@@ -28,6 +28,7 @@ import {
   ArrowLeft, Loader2, Copy, Check, Trash2, Pencil, Save,
   ChevronDown, ChevronUp, BarChart3, Users, Download, X,
 } from 'lucide-react'
+import { toCsvRow } from '../utils/csv'
 
 // ─── Tabs ────────────────────────────────────────────────────────────
 
@@ -254,7 +255,7 @@ function SubmissionRow({ submission, index }: SubmissionRowProps) {
 function downloadCsv(submissions: SessionSubmission[], title: string) {
   const header = 'Name,Auth Method,Score,Max Score,Percentage,Passed,Time (ms),Submitted At\n'
   const rows = submissions.map(s =>
-    [s.participantName, s.authMethod, s.score, s.maxScore, s.percentage, s.passed, s.elapsedMs, s.submittedAt].join(','),
+    toCsvRow([s.participantName, s.authMethod, s.score, s.maxScore, s.percentage, s.passed, s.elapsedMs, s.submittedAt]),
   ).join('\n')
   const blob = new Blob([header + rows], { type: 'text/csv' })
   const url = URL.createObjectURL(blob)

--- a/src/pages/SessionExamPage.tsx
+++ b/src/pages/SessionExamPage.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../context/AuthContext'
 import { useExam } from '../context/ExamContext'
 import { useLanguage } from '../context/LanguageContext'
 import { labels } from '../utils/labels'
+import { isValidNickname } from '../utils/nickname'
 import { fetchSession } from '../utils/sessions'
 import type { ExamSession } from '../data/sessionSchema'
 import { getSessionStatus } from '../data/sessionSchema'
@@ -176,11 +177,14 @@ export function SessionExamPage() {
             placeholder={t(labels.sessionNicknamePlaceholder)}
             className="w-full px-3 py-2 rounded-xl border border-border bg-surface-alt text-sm focus:outline-2 focus:outline-primary"
             maxLength={50}
-            onKeyDown={e => { if (e.key === 'Enter' && nickname.trim()) startSessionExam(nickname.trim()) }}
+            onKeyDown={e => { if (e.key === 'Enter' && isValidNickname(nickname)) startSessionExam(nickname.trim()) }}
           />
+          {nickname.trim().length > 0 && !isValidNickname(nickname) && (
+            <p className="text-xs text-error text-left">{t(labels.sessionNicknameInvalid)}</p>
+          )}
           <button
             onClick={() => startSessionExam(nickname.trim())}
-            disabled={!nickname.trim()}
+            disabled={!isValidNickname(nickname)}
             className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-primary text-white font-medium text-sm hover:opacity-90 transition-all cursor-pointer disabled:opacity-50"
           >
             <User size={16} />

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,29 @@
+/**
+ * CSV helpers (RFC 4180) with spreadsheet formula-injection neutralization.
+ *
+ * User-supplied values such as participant names can contain commas, quotes or
+ * newlines (which corrupt columns) or a leading =/+/-/@ that Excel and Google
+ * Sheets execute as a formula when the exported file is opened. Both are handled
+ * here so callers can build CSV rows safely.
+ */
+
+/** Leading characters that trigger formula evaluation in spreadsheet apps. */
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/
+
+/** Characters that require the field to be wrapped in double quotes per RFC 4180. */
+const NEEDS_QUOTING = /[",\r\n]/
+
+/** Escape a single value for safe inclusion in a CSV cell. */
+export function escapeCsvField(value: string | number | boolean): string {
+  let s = String(value)
+  // Neutralize formula injection by prefixing a single quote (OWASP guidance).
+  if (FORMULA_TRIGGER.test(s)) s = `'${s}`
+  // RFC 4180: quote fields containing a comma, quote, CR or LF; double inner quotes.
+  if (NEEDS_QUOTING.test(s)) s = `"${s.replace(/"/g, '""')}"`
+  return s
+}
+
+/** Join a row of values into a CSV line with each field escaped. */
+export function toCsvRow(fields: Array<string | number | boolean>): string {
+  return fields.map(escapeCsvField).join(',')
+}

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -339,6 +339,10 @@ export const labels = {
     de: "Dein Anzeigename…",
     en: "Your display name…",
   },
+  sessionNicknameInvalid: {
+    de: "Bitte nur sichtbare Zeichen verwenden (1-50).",
+    en: "Please use visible characters only (1-50).",
+  },
   sessionJoinAsGuest: { de: "Als Gast beitreten", en: "Join as Guest" },
   sessionOrSignIn: { de: "oder melde dich an:", en: "or sign in:" },
   sessionAlreadySubmitted: {

--- a/src/utils/nickname.ts
+++ b/src/utils/nickname.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared nickname validation — used by the guest-join form (frontend) and the
+ * session submit handler (Worker, authoritative). Single source of truth so both
+ * sides agree on what counts as a valid display name.
+ *
+ * Policy ("minimal"): 1-50 characters after trimming, with no control, invisible,
+ * or bidirectional-format characters. International names (umlauts, accents, CJK,
+ * emoji) are intentionally allowed - every render path is XSS-safe via React, so
+ * this is data hygiene against spoofing/corruption, not HTML sanitization.
+ */
+
+export const MAX_NICKNAME_LENGTH = 50
+
+/**
+ * A code point that is invisible and can be used to spoof or corrupt a displayed
+ * name: C0/C1 controls + DEL, zero-width characters, line/paragraph separators,
+ * and bidirectional/format characters. Checked numerically to avoid embedding raw
+ * control characters in source.
+ */
+function isDisallowedCodePoint(c: number): boolean {
+  return (
+    c <= 0x1f ||                    // C0 controls (incl. tab, CR, LF)
+    (c >= 0x7f && c <= 0x9f) ||     // DEL + C1 controls
+    (c >= 0x200b && c <= 0x200f) || // zero-width chars + LRM/RLM
+    c === 0x2028 || c === 0x2029 || // line / paragraph separators
+    (c >= 0x202a && c <= 0x202e) || // bidi embeddings / overrides
+    (c >= 0x2060 && c <= 0x2064) || // word joiner + invisible math operators
+    (c >= 0x2066 && c <= 0x206f) || // bidi isolates + deprecated format chars
+    c === 0xfeff                    // BOM / zero-width no-break space
+  )
+}
+
+/** True if `raw` is an acceptable nickname. Validation operates on the trimmed value. */
+export function isValidNickname(raw: string): boolean {
+  const value = raw.trim()
+  if (value.length < 1 || value.length > MAX_NICKNAME_LENGTH) return false
+  for (const ch of value) {
+    if (isDisallowedCodePoint(ch.codePointAt(0) ?? 0)) return false
+  }
+  return true
+}

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -104,7 +104,9 @@ export async function submitSessionExam(
     ...authHeaders(),
   }
   if (nickname) {
-    headers['X-Participant-Nickname'] = nickname
+    // HTTP header values must be ASCII; percent-encode so non-ASCII characters
+    // (e.g. umlauts like "Schüler") survive transmission intact. Decoded server-side.
+    headers['X-Participant-Nickname'] = encodeURIComponent(nickname)
   }
 
   const res = await fetch(`${WORKER_BASE_URL}/api/sessions/${encodeURIComponent(idOrSlug)}/submit`, {

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for CSV escaping (src/utils/csv.ts) — RFC 4180 quoting plus
+ * spreadsheet formula-injection neutralization.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { escapeCsvField, toCsvRow } from '../src/utils/csv'
+
+const LF = String.fromCharCode(0x0a)
+
+describe('escapeCsvField', () => {
+  it('leaves simple values unchanged', () => {
+    expect(escapeCsvField('Bob')).toBe('Bob')
+    expect(escapeCsvField(42)).toBe('42')
+    expect(escapeCsvField(true)).toBe('true')
+  })
+
+  it('quotes fields containing commas, quotes or newlines', () => {
+    expect(escapeCsvField('Doe, John')).toBe('"Doe, John"')
+    expect(escapeCsvField('a"b')).toBe('"a""b"')
+    expect(escapeCsvField('line1' + LF + 'line2')).toBe('"line1' + LF + 'line2"')
+  })
+
+  it('neutralizes spreadsheet formula injection', () => {
+    expect(escapeCsvField('=1+1')).toBe("'=1+1")
+    expect(escapeCsvField('+SUM(A1)')).toBe("'+SUM(A1)")
+    expect(escapeCsvField('-2')).toBe("'-2")
+    expect(escapeCsvField('@cmd')).toBe("'@cmd")
+  })
+
+  it('applies both formula-neutralization and RFC-4180 quoting', () => {
+    // leading '=' adds the quote-prefix; the comma forces the field to be quoted
+    expect(escapeCsvField('=HYPERLINK(x), y')).toBe('"\'=HYPERLINK(x), y"')
+  })
+})
+
+describe('toCsvRow', () => {
+  it('escapes each field and joins with commas', () => {
+    expect(toCsvRow(['Doe, John', 'github', 10])).toBe('"Doe, John",github,10')
+  })
+})

--- a/tests/nickname.test.ts
+++ b/tests/nickname.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for shared nickname validation (src/utils/nickname.ts).
+ * Control/invisible characters are built via String.fromCharCode to keep the
+ * source readable and free of raw control bytes.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { isValidNickname, MAX_NICKNAME_LENGTH } from '../src/utils/nickname'
+
+describe('isValidNickname', () => {
+  it('accepts normal and international names', () => {
+    for (const n of ['Bob', 'Schüler', 'José', '山田太郎', 'a', '😀 Nina']) {
+      expect(isValidNickname(n)).toBe(true)
+    }
+  })
+
+  it('trims before validating', () => {
+    expect(isValidNickname('  Bob  ')).toBe(true)
+    expect(isValidNickname('   ')).toBe(false)
+    expect(isValidNickname('')).toBe(false)
+  })
+
+  it('enforces the max length on the trimmed value', () => {
+    expect(isValidNickname('a'.repeat(MAX_NICKNAME_LENGTH))).toBe(true)
+    expect(isValidNickname('a'.repeat(MAX_NICKNAME_LENGTH + 1))).toBe(false)
+    expect(isValidNickname(`  ${'a'.repeat(MAX_NICKNAME_LENGTH)}  `)).toBe(true)
+  })
+
+  it('rejects control, newline and tab characters', () => {
+    expect(isValidNickname('Bob' + String.fromCharCode(0x00))).toBe(false)
+    expect(isValidNickname('Bob' + String.fromCharCode(0x0a) + 'Smith')).toBe(false) // LF
+    expect(isValidNickname('Bob' + String.fromCharCode(0x09) + 'Smith')).toBe(false) // tab
+    expect(isValidNickname('Bob' + String.fromCharCode(0x7f))).toBe(false)           // DEL
+  })
+
+  it('rejects zero-width and bidirectional format characters', () => {
+    expect(isValidNickname('Bo' + String.fromCharCode(0x200b) + 'b')).toBe(false) // zero-width space
+    expect(isValidNickname('Bob' + String.fromCharCode(0x202e))).toBe(false)      // RLO bidi override
+    expect(isValidNickname('Bob' + String.fromCharCode(0x2066))).toBe(false)      // LRI bidi isolate
+    // U+FEFF placed in the interior: a trailing one is stripped by String.trim().
+    expect(isValidNickname('Bo' + String.fromCharCode(0xfeff) + 'b')).toBe(false) // BOM / ZWNBSP
+  })
+})

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -184,6 +184,25 @@ describe('submitSessionExam', () => {
 
     expect(fetchCalls[0].init?.headers).toHaveProperty('X-Participant-Nickname', 'Bob')
   })
+
+  it('percent-encodes non-ASCII nicknames so umlauts survive the HTTP header (issue #35)', async () => {
+    mockFetch(() => Response.json(
+      { submission: { score: 15, maxScore: 20, percentage: 75, passed: true } },
+      { status: 201 },
+    ))
+
+    await submitSessionExam('test-slug', {
+      answers: { q1: ['a'] },
+      questionTimes: { q1: 5000 },
+      questionNotes: {},
+      elapsedMs: 20000,
+    }, 'Schüler')
+
+    const header = (fetchCalls[0].init?.headers as Record<string, string>)['X-Participant-Nickname']
+    expect(header).toBe('Sch%C3%BCler')
+    // Round-trips back to the original on the server side.
+    expect(decodeURIComponent(header)).toBe('Schüler')
+  })
 })
 
 // ─── fetchSessionSubmissions ────────────────────────────────────────

--- a/worker/src/questions.ts
+++ b/worker/src/questions.ts
@@ -50,9 +50,8 @@ async function fetchQuestionsAtCommit(commitSha: string, token: string): Promise
 
   if (xmlFiles.length === 0) throw new Error('No XML question files found')
 
-  // @xmldom/xmldom's DOMParser is compatible with parseQuestionXml's parameter type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const domParser = new DOMParser() as any
+  // @xmldom/xmldom's DOMParser structurally satisfies parseQuestionXml's XmlDomParser param
+  const domParser = new DOMParser()
 
   const questions = await Promise.all(
     xmlFiles.map(async (file) => {

--- a/worker/src/sessionSubmissions.ts
+++ b/worker/src/sessionSubmissions.ts
@@ -14,6 +14,7 @@ import { scorePickQuestion, scoreCategoryQuestion } from '../../src/utils/scorin
 import { getQuestionsWithCache } from './questions.ts'
 import { getSession } from './auth.ts'
 import { resolveSession } from './sessions.ts'
+import { isValidNickname } from '../../src/utils/nickname.ts'
 import { z } from 'zod'
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -192,7 +193,13 @@ export async function handleSessionSubmit(idOrSlug: string, request: Request, en
     participantName = jwtSession.name
     participantAvatar = jwtSession.avatar
     authMethod = jwtSession.provider
-  } else if (nickname && nickname.length >= 1 && nickname.length <= 50) {
+  } else if (nickname !== undefined) {
+    if (!isValidNickname(nickname)) {
+      return Response.json(
+        { error: 'Invalid nickname. Use 1–50 characters without control or invisible characters.' },
+        { status: 400 },
+      )
+    }
     participantId = `nickname:${nickname}`
     participantName = nickname
     authMethod = 'nickname'

--- a/worker/src/sessionSubmissions.ts
+++ b/worker/src/sessionSubmissions.ts
@@ -16,6 +16,22 @@ import { getSession } from './auth.ts'
 import { resolveSession } from './sessions.ts'
 import { z } from 'zod'
 
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Decode the participant nickname from its HTTP header. The client percent-encodes
+ * the value so non-ASCII characters (e.g. umlauts like "Schüler") survive transmission.
+ * Falls back to the raw value if it isn't valid percent-encoding (e.g. older clients).
+ */
+function decodeNicknameHeader(raw: string | null): string | undefined {
+  if (raw == null) return undefined
+  try {
+    return decodeURIComponent(raw).trim()
+  } catch {
+    return raw.trim()
+  }
+}
+
 // ─── KV Helpers ──────────────────────────────────────────────────────
 
 function submissionsKey(sessionId: string): string {
@@ -169,7 +185,7 @@ export async function handleSessionSubmit(idOrSlug: string, request: Request, en
   let authMethod: 'github' | 'google' | 'nickname'
 
   const jwtSession = await getSession(request, env)
-  const nickname = request.headers.get('X-Participant-Nickname')?.trim()
+  const nickname = decodeNicknameHeader(request.headers.get('X-Participant-Nickname'))
 
   if (jwtSession) {
     participantId = jwtSession.sub


### PR DESCRIPTION
Closes #35.

## Problem
Guest nicknames containing non-ASCII characters (e.g. `Schüler`) were displayed corrupted in the trainer's result list. The nickname was placed **raw into the `X-Participant-Nickname` HTTP header**; `ü` was transmitted as a lone Latin-1 byte (`0xFC`) and then mis-decoded as UTF-8 on the Worker, becoming the replacement character `�`.

## Changes
This branch carries three related commits:

### 1. Fix the encoding bug (#35)
- Frontend percent-encodes the nickname (`encodeURIComponent`) before setting the header.
- Worker decodes it (`decodeURIComponent`, with a raw fallback for older clients).
- Regression test asserting `Schüler` → `Sch%C3%BCler` round-trips.

### 2. Make `xmlParser.ts` self-contained (type fix)
`src/data/xmlParser.ts` is shared by the browser, the Worker (`@xmldom/xmldom`) and the fallback script (`linkedom`) but referenced the ambient DOM `Element`/`DOMParser`. Under `worker/tsconfig.json` (no DOM lib) those resolved to the wrong types, producing 9 type errors and forcing `as any` casts. Replaced with minimal local structural interfaces (`XmlElement`/`XmlDocument`/`XmlDomParser`); the module now typechecks identically everywhere and the caller casts are removed.

### 3. Nickname validation + CSV export hardening (defense-in-depth)
While investigating, a stored nickname was literally `<script>alert(1)</script>`. Rendering is **already XSS-safe** (React escapes every name sink; no `innerHTML`/`dangerouslySetInnerHTML`), so no HTML-escaping was added. Two real gaps were closed instead:
- **Nickname validation** (`src/utils/nickname.ts`, shared front+back, Worker-authoritative): rejects control/zero-width/bidirectional-format characters, enforces 1–50 chars after trim. International names (umlauts, accents, CJK, emoji) stay allowed.
- **CSV export** (`src/utils/csv.ts`): the trainer submissions export joined names raw, so a comma/quote/newline corrupted columns and a leading `=/+/-/@` executed as a spreadsheet formula. Now applies RFC-4180 quoting + formula-injection neutralization.

## Notes
- **Leaderboard is not affected** — display names there come from the OAuth JWT (UTF-8-safe), never a raw header.
- Validation applies to **new** submissions; pre-existing corrupted names can't be auto-recovered (the corruption is lossy `U+FFFD`).

## Verification
- `tsc --noEmit` clean for both root and `worker/` configs
- `bun test` — 106 pass
- `bun run build` succeeds